### PR TITLE
Clarify the purpose of the app

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <meta name="description" content="Powered by LiveContracts.io &middot; Secured in the Blockchain" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
 
-    <title>LegalFling - Get explicit about sexual consent</title>
+    <title>LegalFling - Get explicit about rules in a sexual relationship</title>
 
     <!-- Favicon -->
     <link rel="shortcut icon" href="./images/favicon.png"/>
@@ -177,7 +177,7 @@
                     <div class="heading-title">
                         <h2 class="title iq-tw-6">Safe sex redefined</h2>
                         <div class="divider"></div>
-                        <p>LegalFling is the first blockchain based app to request and verify explicit consent before having sex.
+                        <p>LegalFling is the first blockchain based app to request and verify explicit rules before having sex.
                         </p>
                     </div>
                 </div>
@@ -197,7 +197,7 @@
                         <i aria-hidden="true" class="ion-ios-color-filter-outline iq-font-blue"></i>
                         <h4 class="iq-tw-6">Blockchain based <span class="iq-font-blue">.</span></h4>
                         <div class="info-03">
-                            <p>The LegalFling app verifies mutual consent.
+                            <p>The LegalFling app verifies mutual rules.
                                 Only the transaction hash is stored and timestamped in the blockchain, so your privacy is guaranteed.</p>
                         </div>
                     </div>
@@ -229,7 +229,7 @@
                         <h2 class="title iq-tw-6">About our app</h2>
                         <div class="divider"></div>
                         <div class="center-block iq-pt-30">
-                            <span class="lead iq-tw-6">LegalFling creates legally binding agreement about sexual consent, which is verifiable through the blockchain.</span>
+                            <span class="lead iq-tw-6">LegalFling creates legally binding agreement about the rules in a sexual relationship, which is verifiable through the blockchain.</span>
                         </div>
                     </div>
                 </div>
@@ -307,7 +307,7 @@
                                     <i aria-hidden="true" class="ion-ios-heart-outline"></i>
                                     <h4 class="iq-tw-6">No hassle</h4>
                                     <div class="fancy-content-01">
-                                        <p>Don't ruin the moment. Asking to sign a contract to have sex can be akward.<br>Get sexual consent with a single tap.</p>
+                                        <p>Don't ruin the moment. Asking to sign a contract to have sex can be akward.<br>Sign a contract with the rules in a sexual relationship with a single tap.</p>
                                     </div>
                                 </div>
                             </a>
@@ -418,12 +418,12 @@
                 <div class="col-md-6 text-left iq-ptb-80 green-bg">
                     <div class="iq-app-info">
                         <h2 class="heading-left iq-font-white white iq-tw-6 ">App screenshots</h2>
-                        <div class="lead iq-tw-6 iq-mb-20">LegalFling allows you to request consent from any of your contacts. Sit back and relax while your fling confirms.
+                        <div class="lead iq-tw-6 iq-mb-20">LegalFling allows you to request a contract from any of your contacts. Sit back and relax while your fling confirms.
                         </div>
                         <h4 class="iq-mt-50 iq-font-white iq-tw-6 iq-mb-15">Easy as one, two, three</h4>
                         <p class="">During a fun night you meet your fling. Now it's time to get consent. Does your fling really want to take it further?
                         Simply open the LegalFling app, scroll to your contacts and send a request. Your sexual preferences, including your do's and don'ts are automatically
-                        communicated.</p>
+                        communicated. Now, simply verbally communicate your consent.</p>
                         <p>Are you into BDSM but your fling isn't? LegalFling matches sexual preferences automatically, so you're immediately aware what your fling doesn't
                             appreciate and will not consent to.</p>
                         <p>Hopefully you will not be needing this further down the road. But just in case, feel safe knowing that there is a legally binding agreement. Any violation can be


### PR DESCRIPTION
In PR #5, @jansy explained that the purpose of the app is not to prove consent, but rather to mutually
communicate rules and DOs and DON'Ts in a relationship. This is an attempt at updating the description
on the website to reflect that.

Also since there are no legal advantages of using the app for **consent**, the advice is updated to simply use verbal consent instead, which was already what would be used to revoke consent.

jasny commented:
> I'm afraid you're misunderstanding the point of LegalFling. The apps is not about proving you have consent. There is no way you can prove consent through an app or any other type of technology.
> 
> You don't create a contract to prove something. You create a a contract to clearly and unambiguously set the rules of a relationship. If that contact is broken, then you need to provide proof that it is, through other means.
> 
> So to be absolutely clear
> 
> LegalFling is not a tool to prove consent. You can't prove consent!